### PR TITLE
Remove console.log statement after close event

### DIFF
--- a/lib/samsung-remote.js
+++ b/lib/samsung-remote.js
@@ -79,7 +79,7 @@ var Remote = function(config) {
         });
 
         socket.on('close', function () {
-            console.log('Samsung Remote Client: disconnected from ' + config.ip + ':' + config.port);
+            //console.log('Samsung Remote Client: disconnected from ' + config.ip + ':' + config.port);
         });
 
         socket.on('error', function(error) {


### PR DESCRIPTION
This would make the library a little bit cleaner looking.

My package https://github.com/Glavin001/tv-remote-cli does not look so good with all of this extra logging:

``` bash
❯ tv-remote
TV$ connect
Samsung Remote Client: disconnected from 192.168.1.103:55000
Samsung Remote Client: disconnected from 192.168.1.0:55000
Samsung Remote Client: disconnected from 192.168.1.255:55000
Connecting to 192.168.1.126
TV$ Samsung Remote Client: disconnected from 192.168.1.102:55000
Samsung Remote Client: disconnected from 192.168.1.105:55000
Samsung Remote Client: disconnected from 192.168.1.1:55000
Samsung Remote Client: disconnected from 192.168.1.126:55000
Samsung Remote Client: disconnected from 192.168.1.137:55000
Samsung Remote Client: disconnected from 192.168.1.123:55000
Samsung Remote Client: disconnected from 192.168.1.141:55000
Samsung Remote Client: disconnected from 192.168.1.111:55000
```

Without this `console.log` statement:

``` bash
❯ tv-remote
TV$ connect
Connecting to 192.168.1.126
TV$
```

Beautiful.

Thank you!
