### PR TITLE
Fix #6 - Switching to use the node.js module ping to be os-independent.

### DIFF
--- a/lib/samsung-remote.js
+++ b/lib/samsung-remote.js
@@ -100,13 +100,13 @@ var Remote = function(config) {
     };
 
     this.isAlive = function(done) {
-        return exec("ping -c 1 " + config.ip, function (error, stdout, stderr) {
-            if (error) {
-                done(1);
-            } else {
-                done(0);
-            }
-        });
+	require("ping").sys.probe(config.ip, function (isAlive) {
+	    if (isAlive) {
+		done(0);
+	    } else {
+		done(1);
+	    }
+	});
     };
 
     this.config = config;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samsung-remote",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Remote client for Samsung SmartTV",
   "main": "index.js",
   "author": {
@@ -13,7 +13,9 @@
     "smarttv",
     "remote"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "ping" : "*"
+    },
   "repository": {
     "type": "git",
     "url": "https://github.com/natalan/samsung-remote.git"


### PR DESCRIPTION
Unfortunately we cannot use net-ping since this relies on raw-socket.

This being my first node.js contribution ever I hope I did it right by increasing the version number and such :) 
