### PR TITLE
Allow users to change the name of the remote that appears when prompted for permissions and under AllShare settings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Usage
 var SamsungRemote = require('samsung-remote');
 var remote = new SamsungRemote({
     ip: '192.168.1.13', // required: IP address of your Samsung Smart TV
-    remoteName: 'NodeJS Samsung Remote'
+    remoteName: 'NodeJS Samsung Remote' // required: Name of the remote (appears on the TV when prompted for permission)
 });
 
 remote.send('KEY_VOLUP', function callback(err) {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Usage
 ```javascript
 var SamsungRemote = require('samsung-remote');
 var remote = new SamsungRemote({
-    ip: '192.168.1.13' // required: IP address of your Samsung Smart TV
+    ip: '192.168.1.13', // required: IP address of your Samsung Smart TV
+    remoteName: 'NodeJS Samsung Remote'
 });
 
 remote.send('KEY_VOLUP', function callback(err) {

--- a/lib/samsung-remote.js
+++ b/lib/samsung-remote.js
@@ -10,11 +10,12 @@ var chr = String.fromCharCode,
 var Remote = function(config) {
 
     if (!config.ip) throw new Error("TV IP address is required");
+    if (!config.remoteName) throw new Error("TV Remote Name is required")
 
     config.host = config.host || {
         ip: "127.0.0.1",
         mac: "00:00:00:00",
-        name: "NodeJS Samsung Remote"
+        name: config.remoteName
     };
 
     config.appString = config.appString || "iphone..iapp.samsung";


### PR DESCRIPTION
Allow users to change the name of the remote that appears when prompted for permissions and under AllShare settings.